### PR TITLE
Hide global-scope completions on non-this member access

### DIFF
--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -992,6 +992,12 @@ describe('Completion', () => {
             { label: 'StaticFunction', kind: 3 },
         ]);
     });
+
+    it('Can complete methods for non-this parameter', () => {
+        const completion = getCompletion('var foo; foo.', 14);
+        expect(completion).toEqual([]);
+    });
+
 });
 
 describe('Signature Help', () => {


### PR DESCRIPTION
Fixes an issue where when requesting completion suggestions for an object access query, all globally-scoped items (functions, constants, ...) were returned. The extension cannot provide completion details for objects, so show no suggestions.