### PR TITLE
Send disconnect request after getting pid list

### DIFF
--- a/client/src/activatePolDebug.ts
+++ b/client/src/activatePolDebug.ts
@@ -119,7 +119,13 @@ class PolDebugConfigurationProvider implements vscode.DebugConfigurationProvider
                     vscode.window.showErrorMessage(`Could not get process list from debug server: ${e.message}`).then(_ => { });
                     return undefined;
                 } finally {
-                    client?.destroy();
+                    try {
+                        await client?.request('disconnect');
+                    } catch {
+                        // Ignore errors on disconnect
+                    } finally {
+                        client?.destroy();
+                    }
                 }
             }
         }


### PR DESCRIPTION
The `cppdap` library used in `polserver` may not correctly mark a closed socket as invalid, and continuously attempt to read from it.

Send a `disconnect` request to the server after getting the process list, which `polserver` handles by closing the dap session.

Refs:
- Issue in `cppdap`: https://github.com/google/cppdap/issues/154
- `after_disconnect()` in `polserver`: https://github.com/polserver/polserver/blob/bc5e650ea6cfced67dbfab8e7a848ec0453bb7af/pol-core/pol/dap/clientthread.cpp#L794-L797