### PR TITLE
Add support for enum class

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 cmake_policy(SET CMP0042 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 
 project (vscode-escript-native)
 

--- a/native/cpp/compiler/CompletionBuilder.cc
+++ b/native/cpp/compiler/CompletionBuilder.cc
@@ -224,9 +224,7 @@ std::vector<CompletionItem> CompletionBuilder::context()
         {
           // If we've added a constant with this name already, we need to prefix
           // it with `::` to signal it is global scope.
-          std::string prefix =
-              calling_scope_consts.find( constant->name.name ) != calling_scope_consts.end() ? "::"
-                                                                                             : "";
+          std::string prefix = calling_scope_consts.contains( constant->name.name ) ? "::" : "";
           results.push_back(
               CompletionItem{ prefix + constant->name.name, CompletionItemKind::Constant } );
         }

--- a/native/cpp/compiler/CompletionBuilder.cc
+++ b/native/cpp/compiler/CompletionBuilder.cc
@@ -3,9 +3,17 @@
 #include <set>
 
 #include "bscript/compiler/ast/ClassDeclaration.h"
+#include "bscript/compiler/ast/ConstDeclaration.h"
 #include "bscript/compiler/ast/Identifier.h"
 #include "bscript/compiler/ast/MemberAssignment.h"
+#include "bscript/compiler/ast/ModuleFunctionDeclaration.h"
+#include "bscript/compiler/ast/UserFunction.h"
+#include "bscript/compiler/file/SourceFile.h"
+#include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/ScopeName.h"
+#include "bscript/compiler/model/ScopeTree.h"
+#include "bscript/compiler/model/Variable.h"
+#include <EscriptGrammar/EscriptLexer.h>
 
 #include "clib/strutil.h"
 
@@ -266,53 +274,4 @@ std::vector<CompletionItem> CompletionBuilder::context()
 
   return results;
 }
-
-antlrcpp::Any CompletionBuilder::visitClassDeclaration(
-    EscriptParser::ClassDeclarationContext* ctx )
-{
-  if ( ctx->IDENTIFIER() )
-  {
-    Pol::Bscript::Compiler::Range range( *ctx );
-    if ( range.contains( position ) )
-    {
-      calling_scope = ctx->IDENTIFIER()->getText();
-    }
-  }
-
-  return visitChildren( ctx );
-}
-
-antlrcpp::Any CompletionBuilder::visitFunctionDeclaration(
-    EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx )
-{
-  if ( ctx->IDENTIFIER() )
-  {
-    Pol::Bscript::Compiler::Range range( *ctx );
-    if ( range.contains( position ) )
-    {
-      current_user_function = ctx->IDENTIFIER()->getText();
-    }
-  }
-
-  return visitChildren( ctx );
-}
-
-antlrcpp::Any CompletionBuilder::visitChildren( antlr4::tree::ParseTree* node )
-{
-  for ( auto* child : node->children )
-  {
-    if ( auto* ctx = dynamic_cast<antlr4::ParserRuleContext*>( child ) )
-    {
-      Pol::Bscript::Compiler::Range range( *ctx );
-      if ( range.contains( position ) )
-      {
-        nodes.push_back( ctx );
-      }
-    }
-    child->accept( this );
-  }
-
-  return antlrcpp::Any();
-}
-
 }  // namespace VSCodeEscript::CompilerExt

--- a/native/cpp/compiler/CompletionBuilder.cc
+++ b/native/cpp/compiler/CompletionBuilder.cc
@@ -150,7 +150,7 @@ std::vector<CompletionItem> CompletionBuilder::context()
   {
     for ( auto* constant : workspace.scope_tree.list_constants( query ) )
     {
-      results.push_back( CompletionItem{ constant->identifier, CompletionItemKind::Constant } );
+      results.push_back( CompletionItem{ constant->name.string(), CompletionItemKind::Constant } );
     }
 
     for ( auto variable : workspace.scope_tree.list_variables( query, position ) )

--- a/native/cpp/compiler/CompletionBuilder.h
+++ b/native/cpp/compiler/CompletionBuilder.h
@@ -1,10 +1,14 @@
-#ifndef VSCODEESCRIPT_COMPLETIONBUILDER_H
-#define VSCODEESCRIPT_COMPLETIONBUILDER_H
+#pragma once
 
-#include "SemanticContextBuilder.h"
 #include <optional>
 #include <string>
 #include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class CompilerWorkspace;
+class Position;
+}  // namespace Pol::Bscript::Compiler
 
 namespace VSCodeEscript::CompilerExt
 {
@@ -47,7 +51,7 @@ struct CompletionItem
   std::optional<CompletionItemKind> kind;
 };
 
-class CompletionBuilder : public EscriptGrammar::EscriptParserBaseVisitor
+class CompletionBuilder
 {
 public:
   CompletionBuilder( Pol::Bscript::Compiler::CompilerWorkspace&,
@@ -55,21 +59,11 @@ public:
 
   std::vector<CompletionItem> context();
 
-  virtual antlrcpp::Any visitClassDeclaration(
-      EscriptGrammar::EscriptParser::ClassDeclarationContext* ctx ) override;
-  virtual antlrcpp::Any visitFunctionDeclaration(
-      EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx ) override;
-
-  virtual antlrcpp::Any visitChildren( antlr4::tree::ParseTree* node ) override;
-
 protected:
   Pol::Bscript::Compiler::CompilerWorkspace& workspace;
-  Pol::Bscript::Compiler::Position position;
-  std::vector<antlr4::ParserRuleContext*> nodes;
+  const Pol::Bscript::Compiler::Position& position;
   std::string calling_scope = "";
   std::string current_user_function = "";
 };
 
 }  // namespace VSCodeEscript::CompilerExt
-
-#endif  // VSCODEESCRIPT_COMPLETIONBUILDER_H

--- a/native/cpp/compiler/CompletionBuilder.h
+++ b/native/cpp/compiler/CompletionBuilder.h
@@ -7,7 +7,7 @@
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
-class Position;
+struct Position;
 }  // namespace Pol::Bscript::Compiler
 
 namespace VSCodeEscript::CompilerExt

--- a/native/cpp/compiler/HoverBuilder.cc
+++ b/native/cpp/compiler/HoverBuilder.cc
@@ -11,7 +11,7 @@
 #include "clib/strutil.h"
 
 #include <algorithm>
-#include <boost/range/adaptor/sliced.hpp>
+#include <ranges>
 #include <regex>
 #include <string>
 #include <tinyxml/tinyxml.h>
@@ -70,8 +70,7 @@ std::string parameters_to_string(
 {
   bool added = false;
   std::string result;
-  for ( const auto& param_ref :
-        boost::adaptors::slice( params, exclude_first ? 1 : 0, params.size() ) )
+  for ( const auto& param_ref : params | std::views::drop( exclude_first ? 1 : 0 ) )
   {
     auto& param = param_ref.get();
     if ( added )

--- a/native/cpp/compiler/HoverBuilder.cc
+++ b/native/cpp/compiler/HoverBuilder.cc
@@ -47,11 +47,11 @@ std::optional<HoverResult> HoverBuilder::get_constant(
     Pol::Bscript::Compiler::ConstDeclaration* const_decl )
 {
   std::string hover = "```escriptdoc\n(constant) ";
-  hover += const_decl->identifier;
+  hover += const_decl->name.string();
   hover += " := ";
   hover += replace_literal_tags( const_decl->expression().describe() );
   hover += "\n```";
-  HoverResult result{ HoverResult::SymbolType::CONSTANT, const_decl->identifier, hover };
+  HoverResult result{ HoverResult::SymbolType::CONSTANT, const_decl->name.string(), hover };
   return append_comment( const_decl, result );
 }
 

--- a/native/cpp/compiler/SemanticContextBuilder.h
+++ b/native/cpp/compiler/SemanticContextBuilder.h
@@ -687,9 +687,16 @@ std::optional<T> SemanticContextBuilder<T>::context()
     else if ( auto* ctx =
                   dynamic_cast<EscriptGrammar::EscriptParser::ScopedIdentifierContext*>( node ) )
     {
-      return try_constant_or_variable(
-          fmt::format( "{}::{}", ctx->scope ? ctx->scope->getText() : "",
-                       ctx->identifier ? ctx->identifier->getText() : "" ) );
+      std::string prefix = "";
+      if ( ctx->scope )
+      {
+        auto scope = ctx->scope->getText();
+        if ( !scope.empty() )
+        {
+          prefix = scope + "::";
+        }
+      }
+      return try_constant_or_variable( prefix + ctx->identifier->getText() );
     }
     else if ( auto* ctx =
                   dynamic_cast<EscriptGrammar::EscriptParser::ClassParameterListContext*>( node ) )

--- a/native/cpp/compiler/SemanticContextBuilder.h
+++ b/native/cpp/compiler/SemanticContextBuilder.h
@@ -687,8 +687,9 @@ std::optional<T> SemanticContextBuilder<T>::context()
     else if ( auto* ctx =
                   dynamic_cast<EscriptGrammar::EscriptParser::ScopedIdentifierContext*>( node ) )
     {
-      return try_variable( fmt::format( "{}::{}", ctx->scope ? ctx->scope->getText() : "",
-                                        ctx->identifier ? ctx->identifier->getText() : "" ) );
+      return try_constant_or_variable(
+          fmt::format( "{}::{}", ctx->scope ? ctx->scope->getText() : "",
+                       ctx->identifier ? ctx->identifier->getText() : "" ) );
     }
     else if ( auto* ctx =
                   dynamic_cast<EscriptGrammar::EscriptParser::ClassParameterListContext*>( node ) )

--- a/native/cpp/compiler/SemanticContextBuilder.h
+++ b/native/cpp/compiler/SemanticContextBuilder.h
@@ -56,6 +56,8 @@ public:
 
   virtual antlrcpp::Any visitClassDeclaration(
       EscriptGrammar::EscriptParser::ClassDeclarationContext* ctx ) override;
+  virtual antlrcpp::Any visitEnumStatement(
+      EscriptGrammar::EscriptParser::EnumStatementContext* ctx ) override;
   virtual antlrcpp::Any visitFunctionDeclaration(
       EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx ) override;
   virtual antlrcpp::Any visitChildren( antlr4::tree::ParseTree* node ) override;
@@ -561,6 +563,17 @@ std::optional<T> SemanticContextBuilder<T>::context()
         if ( contains( id ) )
         {
           auto name = id->getText();
+
+          // Try scoped symbol first, as long as name is not already scoped.
+          if ( !calling_scope.empty() && name.find( "::" ) == std::string::npos )
+          {
+            if ( auto result =
+                     try_constant_or_variable( fmt::format( "{}::{}", calling_scope, name ) ) )
+            {
+              return result;
+            }
+          }
+
           return try_constant_or_variable( name );
         }
       }
@@ -770,6 +783,23 @@ inline std::any SemanticContextBuilder<T>::visitClassDeclaration(
     if ( range.contains( position ) )
     {
       calling_scope = ctx->IDENTIFIER()->getText();
+    }
+  }
+
+  return visitChildren( ctx );
+}
+template <typename T>
+inline std::any SemanticContextBuilder<T>::visitEnumStatement(
+    EscriptGrammar::EscriptParser::EnumStatementContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER(); identifier && ctx->CLASS() )
+  {
+    Pol::Bscript::Compiler::Range range( *ctx );
+
+    // Set the calling scope if we are visiting a class declaration inside our range.
+    if ( range.contains( position ) )
+    {
+      calling_scope = identifier->getText();
     }
   }
 

--- a/native/cpp/compiler/SignatureHelpBuilder.cc
+++ b/native/cpp/compiler/SignatureHelpBuilder.cc
@@ -9,7 +9,7 @@
 #include "bscript/compiler/ast/ModuleFunctionDeclaration.h"
 #include "bscript/compiler/ast/UserFunction.h"
 #include "clib/strutil.h"
-#include <boost/range/adaptor/sliced.hpp>
+#include <ranges>
 #include <stack>
 
 using namespace Pol::Bscript::Compiler;
@@ -43,9 +43,7 @@ SignatureHelp make_signature_help(
     if ( xmlDoc.has_value() )
       parsed = XmlDocParser::parse_function( xmlDoc.value(), function_name );
   }
-
-  for ( const auto& param_ref :
-        params | boost::adaptors::sliced( skip_first_param ? 1 : 0, params.size() ) )
+  for ( const auto& param_ref : params | std::views::drop( skip_first_param ? 1 : 0 ) )
   {
     auto& param = param_ref.get();
     if ( added )

--- a/native/cpp/napi/LSPWorkspace.cc
+++ b/native/cpp/napi/LSPWorkspace.cc
@@ -30,7 +30,8 @@ LSPWorkspace::LSPWorkspace( const Napi::CallbackInfo& info )
 
   if ( info.Length() < 1 || !info[0].IsObject() )
   {
-    Napi::TypeError::New( env, Napi::String::New( env, "Invalid arguments: arguments[0] is not an object" ) )
+    Napi::TypeError::New(
+        env, Napi::String::New( env, "Invalid arguments: arguments[0] is not an object" ) )
         .ThrowAsJavaScriptException();
   }
 
@@ -78,7 +79,7 @@ void recurse_collect( const fs::path& basedir, std::set<std::string>* files_src,
   for ( auto dir_itr = fs::recursive_directory_iterator( basedir, ec );
         dir_itr != fs::recursive_directory_iterator(); ++dir_itr )
   {
-    if ( auto fn = dir_itr->path().filename().u8string(); !fn.empty() && *fn.begin() == '.' )
+    if ( auto fn = dir_itr->path().filename().string(); !fn.empty() && *fn.begin() == '.' )
     {
       if ( dir_itr->is_directory() )
         dir_itr.disable_recursion_pending();
@@ -88,10 +89,10 @@ void recurse_collect( const fs::path& basedir, std::set<std::string>* files_src,
       continue;
     const auto ext = dir_itr->path().extension();
     if ( !ext.compare( ".inc" ) )
-      files_inc->insert( fs::canonical( dir_itr->path() ).u8string() );
+      files_inc->insert( fs::canonical( dir_itr->path() ).string() );
     else if ( !ext.compare( ".src" ) || !ext.compare( ".hsr" ) ||
               ( compilercfg.CompileAspPages && !ext.compare( ".asp" ) ) )
-      files_src->insert( fs::canonical( dir_itr->path() ).u8string() );
+      files_src->insert( fs::canonical( dir_itr->path() ).string() );
   }
 }
 
@@ -210,8 +211,8 @@ Napi::Value LSPWorkspace::Open( const Napi::CallbackInfo& info )
         .ThrowAsJavaScriptException();
   }
 
-  _workspaceRoot = std::filesystem::u8path( info[0].As<Napi::String>().Utf8Value() );
-  std::string cfg( ( _workspaceRoot / "scripts" / "ecompile.cfg" ).u8string() );
+  _workspaceRoot = std::filesystem::path( info[0].As<Napi::String>().Utf8Value() );
+  std::string cfg( ( _workspaceRoot / "scripts" / "ecompile.cfg" ).string() );
 
   try
   {
@@ -263,7 +264,7 @@ Napi::Value LSPWorkspace::Reopen( const Napi::CallbackInfo& info )
     return Napi::Value();
   }
 
-  std::string cfg( ( _workspaceRoot / "scripts" / "ecompile.cfg" ).u8string() );
+  std::string cfg( ( _workspaceRoot / "scripts" / "ecompile.cfg" ).string() );
 
   try
   {
@@ -345,7 +346,7 @@ void LSPWorkspace::make_absolute( std::string& path )
   std::filesystem::path filepath( path );
   if ( filepath.is_relative() )
   {
-    path = ( _workspaceRoot / filepath ).u8string();
+    path = ( _workspaceRoot / filepath ).string();
   }
 }
 
@@ -383,7 +384,7 @@ std::unique_ptr<Compiler::Compiler> LSPWorkspace::make_compiler()
 
 Napi::Value LSPWorkspace::GetWorkspaceRoot( const Napi::CallbackInfo& info )
 {
-  return Napi::String::New( info.Env(), _workspaceRoot.generic_u8string() );
+  return Napi::String::New( info.Env(), _workspaceRoot.generic_string() );
 }
 
 Napi::Value LSPWorkspace::GetConfigValue( const Napi::CallbackInfo& info )

--- a/native/package.json
+++ b/native/package.json
@@ -28,12 +28,12 @@
 		]
 	},
 	"scripts": {
-		"build": "cmake-js build --CDNO_PCH=ON && tsc",
-		"rebuild": "cmake-js rebuild --CDNO_PCH=ON && tsc",
+		"build": "cmake-js build --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc",
+		"rebuild": "cmake-js rebuild --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc",
 		"clean": "cmake-js clean && rimraf out",
-		"build-debug": "cmake-js build -B Debug --CDNO_PCH=ON && tsc",
-		"rebuild-debug": "cmake-js rebuild -B Debug --CDNO_PCH=ON && tsc",
-		"build-relwithdebinfo": "cmake-js build -B RelWithDebInfo --CDNO_PCH=ON && tsc",
-		"rebuild-relwithdebinfo": "cmake-js rebuild -B RelWithDebInfo --CDNO_PCH=ON && tsc"
+		"build-debug": "cmake-js build -B Debug --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc",
+		"rebuild-debug": "cmake-js rebuild -B Debug --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc",
+		"build-relwithdebinfo": "cmake-js build -B RelWithDebInfo --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc",
+		"rebuild-relwithdebinfo": "cmake-js rebuild -B RelWithDebInfo --CDNO_PCH=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON && tsc"
 	}
 }

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -242,6 +242,26 @@ describe('Hover - SRC', () => {
         expect(hover).toEqual(escriptdoc('(constant) foo := 3'));
     });
 
+    it('Can hover unscoped enum class constant inside enum class', () => {
+        const hover = getHover('enum class MyEnum FOO := 1, BAR := MyEnum::FOO * 2, BAZ := BAR * 2 endenum', 60);
+        expect(hover).toEqual(escriptdoc('(constant) MyEnum::BAR := 2'));
+    });
+
+    it('Can hover unscoped enum class constant with same name as global constant inside enum class', () => {
+        const hover = getHover('const BAR := 123; enum class MyEnum FOO := 1, BAR := MyEnum::FOO * 2, BAZ := BAR * 2 endenum', 78);
+        expect(hover).toEqual(escriptdoc('(constant) MyEnum::BAR := 2'));
+    });
+
+    it('Can hover scoped enum class constant inside enum class', () => {
+        const hover = getHover('enum class MyEnum FOO := 1, BAR := MyEnum::FOO * 2, BAZ := BAR * 2 endenum', 45);
+        expect(hover).toEqual(escriptdoc('(constant) MyEnum::FOO := 1'));
+    });
+
+    it('Can hover empty-scoped constant inside enum class', () => {
+        const hover = getHover('const BLUB := 321; enum class MyEnum FOO := 1, BAR := MyEnum::FOO * 2, BAZ := BAR * 2, BOB := ::BLUB endenum', 98);
+        expect(hover).toEqual(escriptdoc('(constant) BLUB := 321'));
+    });
+
     it('Can hover variable', () => {
         const hover = getHover('var hello := 1;', 5);
         expect(hover).toEqual(escriptdoc('(variable) hello'));

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -996,6 +996,16 @@ describe('Completion', () => {
         expect(completion).toEqual([{ label: 'varLocal', kind: 6 }, { label: 'varGlobal', kind: 6 }]);
     });
 
+    it('Can complete enum class constants, prefixing global scope `::` only for duplicate constants', () => {
+        const completion = getCompletion('const ZAR := 4; const ZAT := 5; enum class MyEnum FOO := 1, ZAR := MyEnum::FOO * 2, ZAZ := ZA endenum', 93);
+        expect(completion).toEqual([
+            { label: 'ZAR', kind: 21 },  // in enum scope
+            { label: 'ZAZ', kind: 21 },  // in enum scope
+            { label: '::ZAR', kind: 21 }, // in global scope, since duplicated, needs :: prefix
+            { label: 'ZAT', kind: 21 } // in global scope, not duplicated, does not need :: prefix
+        ]);
+    });
+
     it('Will not complete class user function when not in scope', () => {
         const completion = getCompletion('class Foo() function Foo(this) Meth endfunction function Method(this) endfunction function Static() endfunction endclass Foo::Meth; Meth;', 136);
         expect(completion).toEqual([]);

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -227,6 +227,11 @@ describe('Hover - SRC', () => {
         expect(hover).toEqual(escriptdoc('(constant) hello := 1'));
     });
 
+    it('Can hover enum class constants', () => {
+        const hover = getHover('enum class Races HUMANS := "Humans", ORCS := "ORCS" endenum Races::HUMANS;', 70);
+        expect(hover).toEqual(escriptdoc('(constant) Races::HUMANS := "Humans"'));
+    });
+
     it('Can hover variable', () => {
         const hover = getHover('var hello := 1;', 5);
         expect(hover).toEqual(escriptdoc('(variable) hello'));
@@ -937,6 +942,14 @@ describe('Completion', () => {
             { label: 'CRMULTI_IGNORE_WORLDZ', kind: 21 },
             { label: 'CRMULTI_KEEP_COMPONENTS', kind: 21 },
             { label: 'CRMULTI_RECREATE_COMPONENTS', kind: 21 },
+        ]);
+    });
+
+    it('Can complete enum class constants', () => {
+        const completion = getCompletion('enum class Races HUMANS := "Humans", ORCS := "ORCS" endenum Races;', 65);
+        expect(completion).toEqual([
+            { label: 'Races::HUMANS', kind: 21 },
+            { label: 'Races::ORCS', kind: 21 },
         ]);
     });
 

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -953,6 +953,14 @@ describe('Completion', () => {
         ]);
     });
 
+    it('Can complete enum class constants after ::', () => {
+        const completion = getCompletion('enum class Races HUMANS := "Humans", ORCS := "ORCS" endenum Races::;', 67);
+        expect(completion).toEqual([
+            { label: 'Races::HUMANS', kind: 21 },
+            { label: 'Races::ORCS', kind: 21 },
+        ]);
+    });
+
     it('Can complete variables', () => {
         const completion = getCompletion('var varGlobal; program foo() var varLocal; va; endprogram', 45);
         expect(completion).toEqual([{ label: 'varLocal', kind: 6 }, { label: 'varGlobal', kind: 6 }]);

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -232,6 +232,16 @@ describe('Hover - SRC', () => {
         expect(hover).toEqual(escriptdoc('(constant) Races::HUMANS := "Humans"'));
     });
 
+    it('Can hover empty-scoped global variable', () => {
+        const hover = getHover('var foo := 3; print(::foo);', 24);
+        expect(hover).toEqual(escriptdoc('(variable) foo'));
+    });
+
+    it('Can hover empty-scoped constant', () => {
+        const hover = getHover('const foo := 3; print(::foo);', 25);
+        expect(hover).toEqual(escriptdoc('(constant) foo := 3'));
+    });
+
     it('Can hover variable', () => {
         const hover = getHover('var hello := 1;', 5);
         expect(hover).toEqual(escriptdoc('(variable) hello'));


### PR DESCRIPTION
Add support for hovering, completion, and go-to definition for enum class constants.

Additionally:
- Update polserver to https://github.com/polserver/polserver/commit/a607ce1387de702536f5f0da3d61b923b517d37c
- Update to C++20
- Refactor CompletionBuilder to not rely on parse tree contexts for calling scope and current user function, and instead identify it from tokens.