### PR TITLE
Add support for uninitialized functions

### DIFF
--- a/native/cpp/compiler/HoverBuilder.cc
+++ b/native/cpp/compiler/HoverBuilder.cc
@@ -114,6 +114,18 @@ std::optional<HoverResult> HoverBuilder::get_module_function(
   return append_comment( function_def, result );
 }
 
+std::optional<HoverResult> HoverBuilder::get_uninit_function(
+    UninitializedFunctionDeclaration* function_def )
+{
+  std::string hover = "```escriptdoc\n(uninitialized function) ";
+  hover += function_def->name;
+  hover += "(";
+  hover += parameters_to_string( function_def->parameters(), false );
+  hover += ")\n```";
+  HoverResult result{ HoverResult::SymbolType::USER_FUNCTION, function_def->name, hover };
+  return append_comment( function_def, result );
+}
+
 std::optional<HoverResult> HoverBuilder::get_user_function(
     Pol::Bscript::Compiler::UserFunction* function_def )
 {
@@ -205,6 +217,16 @@ std::optional<HoverResult> HoverBuilder::get_module_function_parameter(
   return append_comment( param, result );
 }
 
+std::optional<HoverResult> HoverBuilder::get_uninit_function_parameter(
+    Pol::Bscript::Compiler::UninitializedFunctionDeclaration* function_def,
+    Pol::Bscript::Compiler::FunctionParameterDeclaration* param )
+{
+  std::string hover = "```escriptdoc\n(parameter) ";
+  hover += param->name.name;
+  hover += "\n```";
+  HoverResult result{ HoverResult::SymbolType::USER_FUNCTION_PARAMETER, param->name.name, hover };
+  return append_comment( param, result );
+}
 
 std::optional<HoverResult> HoverBuilder::get_user_function_parameter(
     Pol::Bscript::Compiler::UserFunction* function_def,

--- a/native/cpp/compiler/HoverBuilder.h
+++ b/native/cpp/compiler/HoverBuilder.h
@@ -59,10 +59,15 @@ public:
   virtual std::optional<HoverResult> get_module_function_parameter(
       Pol::Bscript::Compiler::ModuleFunctionDeclaration* function_def,
       Pol::Bscript::Compiler::FunctionParameterDeclaration* param ) override;
+  virtual std::optional<HoverResult> get_uninit_function(
+      Pol::Bscript::Compiler::UninitializedFunctionDeclaration* ) override;
   virtual std::optional<HoverResult> get_user_function(
       Pol::Bscript::Compiler::UserFunction* ) override;
   virtual std::optional<HoverResult> get_user_function_parameter(
       Pol::Bscript::Compiler::UserFunction* function_def,
+      Pol::Bscript::Compiler::FunctionParameterDeclaration* param ) override;
+  virtual std::optional<HoverResult> get_uninit_function_parameter(
+      Pol::Bscript::Compiler::UninitializedFunctionDeclaration* function_def,
       Pol::Bscript::Compiler::FunctionParameterDeclaration* param ) override;
   virtual std::optional<HoverResult> get_program(
       const std::string& name, Pol::Bscript::Compiler::Program* program ) override;

--- a/native/test/native.spec.ts
+++ b/native/test/native.spec.ts
@@ -381,6 +381,16 @@ describe('Hover - SRC', () => {
         const hover = getHover('function StaticFunction(a0) endfunction class Foo() function Foo(this) ::StaticFunction(0); endfunction endclass StaticFunction("");', 76);
         expect(hover).toEqual(escriptdoc('(user function) StaticFunction( a0 )'));
     });
+
+    it('Can hover uninitialized function declaration', () => {
+        const hover = getHover('class Base() uninit function method( this, default param ); endclass class Child( Base ) function Child( this ) endfunction function method( this, param ) endfunction endclass Child();', 32);
+        expect(hover).toEqual(escriptdoc('(uninitialized function) method( this, param )'));
+    });
+
+    it('Can hover parameter in uninitialized function', () => {
+        const hover = getHover('class Base() uninit function method( this, default param ); endclass class Child( Base ) function Child( this ) endfunction function method( this, param ) endfunction endclass Child();', 54);
+        expect(hover).toEqual(escriptdoc('(parameter) param'));
+    });
 });
 
 describe('Hover - Classes', () => {


### PR DESCRIPTION
- Update polserver to https://github.com/polserver/polserver/commit/82bd2b654aaba933eeeb1dd808fa698f80026e81
- Update `SemanticContextBuilder` to support finding contexts within uninitialized functions and parameters
- Update `HoverBuilder` to provide hover details for uninitialized functions and parameters